### PR TITLE
Changed interpol function argument from char* to char

### DIFF
--- a/cartogram_generator/cartogram.c
+++ b/cartogram_generator/cartogram.c
@@ -37,10 +37,10 @@ void project (BOOLEAN proj_graticule)
   for (i=0; i<n_poly; i++)
     for (j=0; j<n_polycorn[i]; j++) {
       cartcorn[i][j].x =
-            	interpol(polycorn[i][j].x, polycorn[i][j].y, xdisp, "x")
+            	interpol(polycorn[i][j].x, polycorn[i][j].y, xdisp, 'x')
             	+ polycorn[i][j].x;
       cartcorn[i][j].y =
-            	interpol(polycorn[i][j].x, polycorn[i][j].y, ydisp, "y")
+            	interpol(polycorn[i][j].x, polycorn[i][j].y, ydisp, 'y')
             	+ polycorn[i][j].y;
     }
   if (proj_graticule)
@@ -50,8 +50,8 @@ void project (BOOLEAN proj_graticule)
     for (i=0; i<lx*ly; i++) {
       x2 = proj2[i].x;
       y2 = proj2[i].y;
-      proj2[i].x = interpol(x2, y2, xdisp, "x") + x2;
-      proj2[i].y = interpol(x2, y2, ydisp, "y") + y2;
+      proj2[i].x = interpol(x2, y2, xdisp, 'x') + x2;
+      proj2[i].y = interpol(x2, y2, ydisp, 'y') + y2;
     }
   
   /******************************* Free memory. ******************************/
@@ -331,8 +331,8 @@ void inv_project (void)
   
   for (i=0; i<=lx; i++)
     for (j=0; j<=ly; j++) {      
-      projgrid[i][j].x = interpol(i, j, xdisp, "x") + i;      
-      projgrid[i][j].y = interpol(i, j, ydisp, "y") + j;
+      projgrid[i][j].x = interpol(i, j, xdisp, 'x') + i;      
+      projgrid[i][j].y = interpol(i, j, ydisp, 'y') + j;
     }
   
   /************ Project the triangles shown in the lattice above. ************/

--- a/cartogram_generator/cartogram.h
+++ b/cartogram_generator/cartogram.h
@@ -62,7 +62,7 @@ void fill_with_density1 (char *gen_file_name, char *area_file_name,
 void fill_with_density2 (void);
 void read_gen (char *gen_file);
 void ps_figure (char *ps_name, POINT **corn, POINT *proj, BOOLEAN grat);
-double interpol (double x, double y, double *grid, char *zero);
+double interpol (double x, double y, double *grid, char zero);
 void ffb_integrate (void);
 void diff_integrate (void);
 void project (BOOLEAN proj_graticule);

--- a/cartogram_generator/diff_integrate.c
+++ b/cartogram_generator/diff_integrate.c
@@ -149,8 +149,8 @@ void diff_integrate (void)
       /* is inside the rectangle [0, lx] x [0, ly]. This fact guarantees     */
       /* that interpol() is given a point that cannot cause it to fail.      */
       
-      vx_intp[k] = interpol(proj[k].x, proj[k].y, gridvx, "x");
-      vy_intp[k] = interpol(proj[k].x, proj[k].y, gridvy, "y");
+      vx_intp[k] = interpol(proj[k].x, proj[k].y, gridvx, 'x');
+      vy_intp[k] = interpol(proj[k].x, proj[k].y, gridvy, 'y');
     }
     
     accept = FALSE;
@@ -188,10 +188,10 @@ void diff_integrate (void)
 	for (k=0; k<lx*ly; k++) {
 	  vx_intp_half[k] = interpol(proj[k].x + 0.5*delta_t*vx_intp[k],
 				     proj[k].y + 0.5*delta_t*vy_intp[k],
-				     gridvx, "x");
+				     gridvx, 'x');
 	  vy_intp_half[k] = interpol(proj[k].x + 0.5*delta_t*vx_intp[k],
 				     proj[k].y + 0.5*delta_t*vy_intp[k],
-				     gridvy, "y");
+				     gridvy, 'y');
 	  mid[k].x = proj[k].x + vx_intp_half[k] * delta_t;
 	  mid[k].y = proj[k].y + vy_intp_half[k] * delta_t;
 	  

--- a/cartogram_generator/ffb_integrate.c
+++ b/cartogram_generator/ffb_integrate.c
@@ -246,8 +246,8 @@ void ffb_integrate (void)
       /* is inside the rectangle [0, lx] x [0, ly]. This fact guarantees     */
       /* that interpol() is given a point that cannot cause it to fail.      */
       
-      vx_intp[k] = interpol(proj[k].x, proj[k].y, gridvx, "x");
-      vy_intp[k] = interpol(proj[k].x, proj[k].y, gridvy, "y");
+      vx_intp[k] = interpol(proj[k].x, proj[k].y, gridvx, 'x');
+      vy_intp[k] = interpol(proj[k].x, proj[k].y, gridvy, 'y');
     }
     accept = FALSE;
     while (!accept) {
@@ -289,10 +289,10 @@ void ffb_integrate (void)
       	for (k=0; k<lx*ly; k++) {
       	  vx_intp_half[k] = interpol(proj[k].x + 0.5*delta_t*vx_intp[k],
 				     proj[k].y + 0.5*delta_t*vy_intp[k],
-				     gridvx, "x");
+				     gridvx, 'x');
       	  vy_intp_half[k] = interpol(proj[k].x + 0.5*delta_t*vx_intp[k],
 				     proj[k].y + 0.5*delta_t*vy_intp[k],
-				     gridvy, "y");
+				     gridvy, 'y');
       	  mid[k].x = proj[k].x + vx_intp_half[k] * delta_t;
       	  mid[k].y = proj[k].y + vy_intp_half[k] * delta_t;
 	  

--- a/cartogram_generator/ffb_integrate.c
+++ b/cartogram_generator/ffb_integrate.c
@@ -107,7 +107,7 @@ void ffb_calcv (double t)
 /* all the way to the edge (i.e. the slope is 0 consistent with a cosine     */
 /* transform).                                                               */
 
-double interpol (double x, double y, double *grid, char *zero)
+double interpol (double x, double y, double *grid, char zero)
 {
   double delta_x, delta_y, fx0y0, fx0y1, fx1y0, fx1y1, x0, x1, y0, y1;
   
@@ -116,7 +116,7 @@ double interpol (double x, double y, double *grid, char *zero)
     fprintf(stderr, "x=%f, y=%f\n", x, y);
     exit(1);
   }
-  if (strcmp(zero, "x")!=0 && strcmp(zero, "y")!=0) {
+  if (zero != 'x' && zero != 'y' ) {
     fprintf(stderr, "ERROR: unknown argument zero in interpol().\n");
     exit(1);
   }
@@ -132,40 +132,40 @@ double interpol (double x, double y, double *grid, char *zero)
   
   /* Function value at (x0, y0). */
   
-  if ((x<0.5 && y<0.5) || (x<0.5 && strcmp(zero, "x")==0) ||
-      (y<0.5 && strcmp(zero, "y")==0))
+  if ((x<0.5 && y<0.5) || (x<0.5 && zero == 'x') ||
+      (y<0.5 && zero == 'y'))
     fx0y0 = 0.0;
   else
     fx0y0 = grid[(int)x0*ly + (int)y0];
   
   /* Function value at (x0, y1). */
   
-  if ((x<0.5 && y>=ly-0.5) || (x<0.5 && strcmp(zero, "x")==0) ||
-      (y>=ly-0.5 && strcmp(zero, "y")==0))
+  if ((x<0.5 && y>=ly-0.5) || (x<0.5 && zero == 'x') ||
+      (y>=ly-0.5 && zero == 'y'))
     fx0y1 = 0.0;
-  else if (x>=0.5 && y>=ly-0.5 && strcmp(zero, "x")==0)
+  else if (x>=0.5 && y>=ly-0.5 && zero == 'x')
     fx0y1 = grid[(int)x0*ly + ly -1];
   else
     fx0y1 = grid[(int)x0*ly + (int)y1];
   
   /* Function value at (x1, y0). */
   
-  if ((x>=lx-0.5 && y<0.5) || (x>=lx-0.5 && strcmp(zero, "x")==0) ||
-      (y<0.5 && strcmp(zero, "y")==0))
+  if ((x>=lx-0.5 && y<0.5) || (x>=lx-0.5 && zero == 'x') ||
+      (y<0.5 && zero == 'y'))
     fx1y0 = 0.0;
-  else if (x>=lx-0.5 && y>=0.5 && strcmp(zero, "y")==0)
+  else if (x>=lx-0.5 && y>=0.5 && zero == 'y')
     fx1y0 = grid[(lx-1)*ly + (int)y0];
   else
     fx1y0 = grid[(int)x1*ly + (int)y0];
   
   /* Function value at (x1, y1). */
   
-  if ((x>=lx-0.5 && y>=ly-0.5) || (x>=lx-0.5 && strcmp(zero, "x")==0) ||
-      (y>=ly-0.5 && strcmp(zero, "y")==0))
+  if ((x>=lx-0.5 && y>=ly-0.5) || (x>=lx-0.5 && zero == 'x') ||
+      (y>=ly-0.5 && zero == 'y'))
     fx1y1 = 0.0;
-  else if (x>=lx-0.5 && y<ly-0.5 && strcmp(zero, "y")==0)
+  else if (x>=lx-0.5 && y<ly-0.5 && zero == 'y')
     fx1y1 = grid[(lx-1)*ly + (int)y1];
-  else if (x<lx-0.5 && y>=ly-0.5 && strcmp(zero, "x")==0)
+  else if (x<lx-0.5 && y>=ly-0.5 && zero == 'x')
     fx1y1 = grid[(int)x1*ly + ly - 1];
   else
     fx1y1 = grid[(int)x1*ly + (int)y1];


### PR DESCRIPTION
This leads to a 40% global performance increase on a Intel quad-core i7 CPU. This function clearly is the bottleneck of this program: it's being called a million times per iteration and is not optimized. I think the function signature should be among the lines of `void interpol(double **x_output, double **y_output, double *x_input,  double *y_input, double *x_interpolation, double *y_interpolation )` so that it could calculate the four neighbors and their corresponding coefficient only once per point, and also avoid the multiple if's statements.