### PR TITLE
Change to Extern variable declaration for globals to avoid duplicate symbol error (#19)

### DIFF
--- a/cartogram_generator/cartogram.h
+++ b/cartogram_generator/cartogram.h
@@ -53,18 +53,18 @@ typedef struct {
 
 /* Variables for map. */
 
-double *area_err, *cart_area, map_maxx, map_maxy, map_minx, map_miny,
+extern double *area_err, *cart_area, map_maxx, map_maxy, map_minx, map_miny,
   *target_area, *region_perimeter;
-int max_id, n_poly, *n_polycorn, *n_polyinreg, n_reg, *polygon_id, *poly_is_hole,
+extern int max_id, n_poly, *n_polycorn, *n_polyinreg, n_reg, *polygon_id, *poly_is_hole,
   **polyinreg, *region_id, *region_id_inv, *region_na;
-POINT **cartcorn, **origcorn, **polycorn, *proj, *proj2;
-BOOLEAN use_perimeter_threshold;
+extern POINT **cartcorn, **origcorn, **polycorn, *proj, *proj2;
+extern BOOLEAN use_perimeter_threshold;
 
 /* Variables for digitizing the density. */
 
-double *rho_ft, *rho_init;
-fftw_plan plan_fwd;
-int lx, ly;
+extern double *rho_ft, *rho_init;
+extern fftw_plan plan_fwd;
+extern int lx, ly;
 
 /**************************** Function prototypes. ***************************/
 

--- a/cartogram_generator/diff_integrate.c
+++ b/cartogram_generator/diff_integrate.c
@@ -15,9 +15,13 @@
 #define MIN_T (1e3)
 #define MAX_T (1e12)
 
+/***************************** Local variables. ******************************/
+
+static double *gridvx, *gridvy;
+
 /***************************** Global variables. *****************************/
 
-double *gridvx, *gridvy, *rho;
+double *rho;
 fftw_plan plan_gridvx, plan_gridvy, plan_rho;
 
 /**************************** Function prototypes. ***************************/

--- a/cartogram_generator/ffb_integrate.c
+++ b/cartogram_generator/ffb_integrate.c
@@ -12,9 +12,13 @@
 #define INC_AFTER_ACC (1.1)
 #define DEC_AFTER_NOT_ACC (0.75)
 
+/***************************** Local variables. ******************************/
+
+static double *gridvx, *gridvy;
+
 /***************************** Global variables. *****************************/
 
-double *gridvx, *gridvy, *grid_fluxx_init, *grid_fluxy_init;
+double *grid_fluxx_init, *grid_fluxy_init;
 fftw_plan plan_grid_fluxx_init, plan_grid_fluxy_init;
 
 /**************************** Function prototypes. ***************************/

--- a/cartogram_generator/main.c
+++ b/cartogram_generator/main.c
@@ -63,6 +63,24 @@
 //#include <time.h>
 #include "cartogram.h"
 
+/**************************** Variable definitions. **************************/
+/* Variables for map. */
+
+double *area_err;
+double *cart_area, map_maxx, map_maxy, map_minx, map_miny,
+        *target_area, *region_perimeter;
+
+int max_id, n_poly, *n_polycorn, *n_polyinreg, n_reg, *polygon_id, *poly_is_hole,
+        **polyinreg, *region_id, *region_id_inv, *region_na;
+POINT **cartcorn, **origcorn, **polycorn, *proj, *proj2;
+BOOLEAN use_perimeter_threshold;
+
+/* Variables for digitizing the density. */
+
+double *rho_ft, *rho_init;
+fftw_plan plan_fwd;
+int lx, ly;
+
 /**************************** Function prototype. ****************************/
 
 void print_usage (char *program_name);


### PR DESCRIPTION
Due to the issued described in (#19 ), we need to make the global variables as extern, and define them in only one place.
Also, some of the local ones have to be made static, to avoid conflict with other declarations.